### PR TITLE
Add route name to WidgetPage

### DIFF
--- a/lib/src/widget_navigator.dart
+++ b/lib/src/widget_navigator.dart
@@ -233,7 +233,7 @@ class WidgetPage<T> extends Page<T> with RouteDataPage<T> {
   //   child: _child,
   // );
 
-  WidgetPage({required this.child});
+  WidgetPage({required this.child, required super.name});
 
   @override
   Route<T> createRoute(BuildContext context) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.10.0-dev5
 homepage: https://github.com/tomgilder/routemaster
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
   flutter: ">=1.17.0"
 
 dependencies:


### PR DESCRIPTION
In order to get Navigation breadcrumbs working, Sentry needs to know the route `name`. Pretty standard stuff.

This PR forwards the `name` from the `WidgetPage` to the parent `Page` constructor.